### PR TITLE
Upgrade all projects from .NET 6 to .NET 8

### DIFF
--- a/samples/AppStream.DurablePatterns.Samples.CombinedOrchestrator/AppStream.DurablePatterns.Samples.CombinedOrchestrator.csproj
+++ b/samples/AppStream.DurablePatterns.Samples.CombinedOrchestrator/AppStream.DurablePatterns.Samples.CombinedOrchestrator.csproj
@@ -1,31 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
-		<Nullable>enable</Nullable>
-		<OutputType>Exe</OutputType>
-		
-		<!-- It is crucial to include this property -->
-		<FunctionsInDependencies>true</FunctionsInDependencies>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.12.0" />
-	</ItemGroup>
-	<ItemGroup>
-	  <ProjectReference Include="..\..\src\AppStream.DurablePatterns\AppStream.DurablePatterns.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Update="appsettings.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="host.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="local.settings.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
-		</None>
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <!-- It is crucial to include this property -->
+    <FunctionsInDependencies>true</FunctionsInDependencies>
+    <ImplicitUsings>enabled</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AppStream.DurablePatterns\AppStream.DurablePatterns.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+  </ItemGroup>
 </Project>

--- a/src/AppStream.DurablePatterns/AppStream.DurablePatterns.csproj
+++ b/src/AppStream.DurablePatterns/AppStream.DurablePatterns.csproj
@@ -1,55 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<AssemblyName>AppStream.DurablePatterns</AssemblyName>
-		<RootNamespace>AppStream.DurablePatterns</RootNamespace>
-		<MajorVersion>3</MajorVersion>
-		<MinorVersion>1</MinorVersion>
-		<PatchVersion>1</PatchVersion>
-		<Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
-		<FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
-	</PropertyGroup>
-
-	<!-- NuGet Publishing Metadata -->
-	<PropertyGroup>
-		<Title>Durable Patterns</Title>
-		<Authors>Appstream Studio</Authors>
-		<Description>Durable Patterns is a .NET library that simplifies usage of the Durable Function framework when leveraging main use patterns.</Description>
-		<PackageTags>Microsoft Azure WebJobs Durable Extension Orchestration Workflow Functions</PackageTags>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/Appstream-Studio/durable-patterns</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Appstream-Studio/durable-patterns.git</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageIcon>icon.png</PackageIcon>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.2" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>$(AssemblyName).Tests</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\..\assets\icon.png">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-		<None Include="..\..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>AppStream.DurablePatterns</AssemblyName>
+    <RootNamespace>AppStream.DurablePatterns</RootNamespace>
+    <MajorVersion>3</MajorVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>1</PatchVersion>
+    <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
+    <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</FileVersion>
+  </PropertyGroup>
+  <!-- NuGet Publishing Metadata -->
+  <PropertyGroup>
+    <Title>Durable Patterns</Title>
+    <Authors>Appstream Studio</Authors>
+    <Description>Durable Patterns is a .NET library that simplifies usage of the Durable Function framework when leveraging main use patterns.</Description>
+    <PackageTags>Microsoft Azure WebJobs Durable Extension Orchestration Workflow Functions</PackageTags>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Appstream-Studio/durable-patterns</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Appstream-Studio/durable-patterns.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/AppStream.DurablePatterns.Tests/AppStream.DurablePatterns.Tests.csproj
+++ b/test/AppStream.DurablePatterns.Tests/AppStream.DurablePatterns.Tests.csproj
@@ -1,35 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.6.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\AppStream.DurablePatterns\AppStream.DurablePatterns.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AppStream.DurablePatterns\AppStream.DurablePatterns.csproj" />
+  </ItemGroup>
 </Project>

--- a/test/AppStream.DurablePatterns.Tests/AppStream.DurablePatterns.Tests.csproj
+++ b/test/AppStream.DurablePatterns.Tests/AppStream.DurablePatterns.Tests.csproj
@@ -24,4 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AppStream.DurablePatterns\AppStream.DurablePatterns.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the .NET version from 6 to 8. .NET 8 is the latest LTS release. Additionally, it includes a minor change to exclude a project containing tests from code coverage calculation.